### PR TITLE
chore: documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.y4m
+env
+*.csv
+*.md
+*.ods

--- a/README.md
+++ b/README.md
@@ -5,7 +5,27 @@ Optionally you can merge different runs in a ods spreadsheet with the provided p
 
 ## Usage
 
+### Comparison scripts
+
+```sh
+bash compare-all.sh SAMPLEFILE PLATFORM_ID NUMBER_OF_FRAMES
+bash compare-rav1e.sh SAMPLEFILE PLATFORM_ID NUMBER_OF_FRAMES PATH_TO_ENCODER <PATH_TO_ENCODER..>
 ```
-# bash compare-all.sh SAMPLEFILE PLATFORM_ID NUMBER_OF_FRAMES
-# bash compare-rav1e.sh SAMPLEFILE PLATFORM_ID NUMBER_OF_FRAMES PATH_TO_ENCODER <PATH_TO_ENCODER..>
+
+### Merge all the speed tests results
+
+```sh
+python3 -m venv env
+. env/bin/activate
+pip install -r requirements.txt
+python3 merge_all.py SAMPLEFILE PLATFORM_ID NUMBER_OF_FRAMES
 ```
+
+## Test files
+
+You will be able to download test files from
+http://ultravideo.cs.tut.fi/#testsequences
+
+## If you are curious
+
+Just call `set +x` before launching the bash scripts.

--- a/compare-all.sh
+++ b/compare-all.sh
@@ -1,5 +1,5 @@
 . speed-level.sh
 
 for enc in run_aom run_rav1e run_svt; do
-    $enc ${1} ${2} ${3}
+    $enc ${1} ${2} ${3} ${4}
 done

--- a/compare-rav1e.sh
+++ b/compare-rav1e.sh
@@ -3,11 +3,12 @@
 input=${1}
 cpu=${2}
 limit=${3}
+verbose=${4}
 
 shift 3
 
 for enc in ${@}; do
     ENC_rav1e=rav1e-`$enc --version | cut -d ' ' -f 2`
     BIN_rav1e=$enc
-    run_rav1e $input $cpu $limit
+    run_rav1e $input $cpu $limit $verbose
 done

--- a/speed-level.sh
+++ b/speed-level.sh
@@ -2,6 +2,7 @@ function run_aom {
     INFILE="${1}"
     CPU="${2}"
     LIMIT=${3}
+    IS_VERBOSE=${4}
 
     BIN=${BIN_aom:-aomenc}
     aom_version=`"$BIN" --help | grep av1 | cut -d ' ' -f 14`
@@ -14,7 +15,11 @@ function run_aom {
 
     RUN="${NUMACMD} ${BIN} --tile-rows=2 --tile-columns=2 --cpu-used={ss} --threads=16 --limit=${LIMIT} -o ${OUTFILE} ${INFILE}"
 
-    hyperfine -r 2 -P ss ${LEVELS} "$RUN" --export-csv ${OUT}.csv --export-markdown ${OUT}.md
+    VERBOSE_ARG=
+    if [[ -z ${IS_VERBOSE} ]]; then
+        VERBOSE_ARG=--show-output
+    fi
+    hyperfine -r 2 -P ss ${LEVELS} "$RUN" --export-csv ${OUT}.csv --export-markdown ${OUT}.md ${VERBOSE_ARG}
 }
 
 function run_svt {
@@ -28,18 +33,25 @@ function run_svt {
     LEVELS="0 8"
     NAME=`basename ${1} | cut -d . -f 1`
     OUTFILE="~/Encoded/${NAME}_${ENC}_{ss}_l${3}.ivf"
+    IS_VERBOSE=${4}
     OUT="${CPU}-${ENC}-speed-levels-${NAME}-l${3}"
 
 
     RUN="${NUMACMD} ${BIN} --preset {ss} --tile-rows 2 --tile-columns 2 --lp 16 -n ${LIMIT}  -b ${OUTFILE} -i ${INFILE}"
 
-    hyperfine -r 2 -P ss ${LEVELS} "$RUN" --export-csv ${OUT}.csv --export-markdown ${OUT}.md
+    VERBOSE_ARG=
+    if [[ -z ${IS_VERBOSE} ]]; then
+        VERBOSE_ARG=--show-output
+    fi
+    hyperfine -r 2 -P ss ${LEVELS} "$RUN" --export-csv ${OUT}.csv --export-markdown ${OUT}.md ${VERBOSE_ARG}
 }
 
 function run_rav1e {
     INFILE="${1}"
     CPU="${2}"
     LIMIT=${3}
+    IS_VERBOSE=${4}
+
     BIN=${BIN_rav1e:-rav1e}
     rav1e_version=`"$BIN" --version | cut -d ' ' -f 2`
     ENC="${ENC_rav1e:-rav1e-${rav1e_version}}"
@@ -51,7 +63,11 @@ function run_rav1e {
 
     $BIN --version | grep 0.3 -q || OVERRIDE=-y
 
-    RUN="${NUMACMD} ${BIN} --threads 16 --tiles 16 -l ${LIMIT} -s {ss} -o ${OUTFILE} ${INFILE} ${OVERRIDE}"
+    RUN="${NUMACMD} ${BIN} --threads 8 --tiles 16 -l ${LIMIT} -s {ss} -o ${OUTFILE} ${INFILE} ${OVERRIDE}"
 
-    hyperfine -r 2 -P ss $LEVELS "$RUN" --export-csv ${OUT}.csv --export-markdown ${OUT}.md
+    VERBOSE_ARG=
+    if [[ -z ${IS_VERBOSE} ]]; then
+        VERBOSE_ARG=--show-output
+    fi
+    hyperfine -r 2 -P ss $LEVELS "$RUN" --export-csv ${OUT}.csv --export-markdown ${OUT}.md ${VERBOSE_ARG}
 }


### PR DESCRIPTION
tell how to use merge all the results of a measuring session
give the user the possibility to understand what's going on with a verbose output
reset the OVERRIDE parameter when testing rav1e 0.4.0 first and 0.3.5 then